### PR TITLE
fix: overly restrictive intra name sanitization

### DIFF
--- a/server.js
+++ b/server.js
@@ -689,7 +689,7 @@ app.post("/check-user", async (req, res) => {
 	}
 
 	let { username } = req.body;
-    username = username.replace(/[^a-zA-Z]/g, "").toLowerCase();
+    username = username.replace(/[^a-zA-Z0-9-]/g, "").toLowerCase();
 	const localTime = parseInt(req.body.localTime);
 	const userTimezone = `UTC${localTime >= 0 ? "-" : "+"}${Math.abs(localTime) / 60}`; // Convert to readable UTC offset
 

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -245,8 +245,8 @@
 					<h2 class="text-xl font-semibold text-center">Check Your Friend's Campus Status</h2>
 					<form action="/check-user" method="POST" class="mt-4" id="userForm" onsubmit="return startLoading()">
 						<label for="username" class="block">Enter 42 Username:</label>
-						<input type="text" name="username" id="username" required pattern="[a-zA-Z]+" 
-							title="Only letters (a-z | A-Z) are allowed." 
+						<input type="text" name="username" id="username" required pattern="[a-zA-Z0-9-]+" 
+							title="Only letters, digits (0-9), and dashes (-) are allowed." 
 							class="w-full px-3 py-2 bg-gray-600 border border-gray-500 rounded-lg 
 								   focus:outline-none focus:ring-2 focus:ring-blue-500">
 						<input type="hidden" name="localTime" id="localTime">


### PR DESCRIPTION
Proposed fix for reported issue #2 
42 Intra names may contain digits and hyphens, along with letters.
Adjusted frontend and backend input sanitization to account for that.